### PR TITLE
chore(deps): ignore typescript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,15 @@ updates:
     # eslint v9+ plugin majors (eslint-plugin-jest 29, eslint-plugin-github 6, @eslint/js 10,
     # @typescript-eslint/* 8+) require eslint v9 peer dep; this repo is on eslint v8.
     # Ignore plugin majors until an eslint v8→v9 coordinated upgrade.
+    # typescript v6+ deprecates moduleResolution=node10 and requires tsconfig migration
+    # to node16/bundler or ignoreDeprecations: "6.0". Ignore majors until a planned
+    # tsconfig modernization.
     ignore:
       - dependency-name: "@actions/core"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@actions/github"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-plugin-jest"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
TS 6.0 deprecates `moduleResolution=node10` and requires a tsconfig migration to `node16`/`bundler` (or `ignoreDeprecations: "6.0"`). Same pattern as the existing eslint v9 plugin-major ignores — hold back the bot until a planned modernization so the queue stays green.

Closes the auto-bump path that produced #21.