### PR TITLE
fix(update): pin typescript at 5.x via .ncurc.json (fix nightly auto-update)

### DIFF
--- a/.ncurc.json
+++ b/.ncurc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/raineorshine/npm-check-updates/main/src/types/RunOptions.ts",
+  "reject": [
+    "typescript"
+  ]
+}


### PR DESCRIPTION
🤖 AI-generated, review before merging. Heartbeat-shipped fix; verify the ncc/TS6 reasoning matches your preference vs. accepting the TS6 bump with `ignoreDeprecations`.

## Problem

Last 3 nightly `Auto Update Dependencies` runs failed:
- [06-24](https://github.com/austenstone/activity/actions/runs/28066408073) · [06-25](https://github.com/austenstone/activity/actions/runs/28138637663) · [06-26](https://github.com/austenstone/activity/actions/runs/28209300637)

Root cause: `npx npm-check-updates -u` bumps typescript `^5.5.4 → ^6.0.3`, and ncc 0.44.0 then chokes on the now-deprecated `moduleResolution=node10`:

```
TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

## Why not just set `ignoreDeprecations`

The value is version-pinned: `"5.0"` on TS 5, `"6.0"` on TS 6. Adding it to tsconfig pre-update would break the local TS 5 build with `TS5103: Invalid value for '--ignoreDeprecations'`.

## Fix

Add `.ncurc.json` that rejects typescript bumps. Verified locally — ncu now omits typescript from the upgrade list and still surfaces 12 other valid bumps.

## Followup

Revisit once @vercel/ncc ships a release with `moduleResolution=node16/nodenext` or otherwise tolerates the TS 6 deprecation, then drop the reject and accept the bump.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>